### PR TITLE
Use Shiro role-based permissions

### DIFF
--- a/integration-test-app/grails-app/conf/application.groovy
+++ b/integration-test-app/grails-app/conf/application.groovy
@@ -2,6 +2,7 @@ import integration.test.app.Permission
 import integration.test.app.Role
 import integration.test.app.User
 import integration.test.app.UserRole
+import integration.test.app.RolePermission
 
 grails {
 	plugin {
@@ -12,6 +13,7 @@ grails {
 			}
 			authority.className = Role.name
 			shiro.permissionDomainClassName = Permission.name
+			shiro.rolePermissionDomainClassName = RolePermission.name
 		}
 	}
 }

--- a/integration-test-app/grails-app/domain/integration/test/app/RolePermission.groovy
+++ b/integration-test-app/grails-app/domain/integration/test/app/RolePermission.groovy
@@ -12,18 +12,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-security {
+package integration.test.app
 
-	shiro {
+class RolePermission {
+	Role role
+	String permission
 
-		active = true
+	RolePermission(Role role, String permission) {
+		this.role = role
+		this.permission = permission
+	}
 
-		permissionDomainClassName = null // must be set
-
-		rolePermissionDomainClassName = null // if set, will use Role Permissions
-
-		useCache = true
-
-		inspectShiroAnnotations = true
+	static constraints = {
+		permission unique: 'role'
 	}
 }

--- a/integration-test-app/grails-app/init/integration/test/app/BootStrap.groovy
+++ b/integration-test-app/grails-app/init/integration/test/app/BootStrap.groovy
@@ -21,6 +21,9 @@ class BootStrap {
 		save new Permission(user3, 'action:jump')
 		save new Permission(user3, 'action:kick')
 
+		save new RolePermission(roleAdmin, 'printer:admin')
+		save new RolePermission(roleUser, 'printer:use')
+
 		UserRole.create user1, roleAdmin, true
 		UserRole.create user2, roleAdmin, true
 		UserRole.create user2, roleUser, true

--- a/integration-test-app/grails-app/services/integration/test/app/TestService.groovy
+++ b/integration-test-app/grails-app/services/integration/test/app/TestService.groovy
@@ -52,4 +52,10 @@ class TestService {
 
 	@RequiresAuthentication
 	boolean requireAuthentication() { true }
+
+	@RequiresPermissions('printer:admin')
+	boolean requirePrinterAdminPermissions() { true }
+
+	@RequiresPermissions('printer:use')
+	boolean requireUsePrinterPermissions() { true }
 }

--- a/integration-test-app/src/integration-test/groovy/integration/test/app/AnnotatedServiceSpec.groovy
+++ b/integration-test-app/src/integration-test/groovy/integration/test/app/AnnotatedServiceSpec.groovy
@@ -176,6 +176,49 @@ class AnnotatedServiceSpec extends Specification {
 		thrown UnauthorizedException
 	}
 
+	void testRolePermissions() {
+
+		when:
+		testService.requirePrinterAdminPermissions()
+
+		then:
+		thrown UnauthenticatedException
+
+		when:
+		login 'user1'
+
+		then:
+		testService.requirePrinterAdminPermissions()
+
+		when:
+		testService.requireUsePrinterPermissions()
+
+		then:
+		thrown UnauthorizedException
+
+		when:
+		logout()
+		login 'user2'
+
+		then:
+		testService.requirePrinterAdminPermissions()
+		testService.requireUsePrinterPermissions()
+
+		when:
+		logout()
+		login 'user3'
+		testService.requirePrinterAdminPermissions()
+
+		then:
+		thrown UnauthorizedException
+
+		when:
+		testService.requireUsePrinterPermissions()
+
+		then:
+		thrown UnauthorizedException
+	}
+
 	void testRequiresUser() {
 		when:
 		testService.requireUser()

--- a/src/docs/configuration.adoc
+++ b/src/docs/configuration.adoc
@@ -15,9 +15,10 @@ grails.plugin.springsecurity.shiro.permissionDomainClassName =
 
 [width="100%",options="header"]
 |====================
-| *Name*                            | *Default*           | *Meaning*
-| shiro.active                      | `true`              | if `false` the plugin is disabled
-| shiro.permissionDomainClassName   | none, must be set   | the full class name of the permission domain class
-| shiro.useCache                    | `true`              | whether to cache permission lookup; if you disable this they will be loaded from the database for every request
-| shiro.inspectShiroAnnotations     | `true`              | Whether to enable/disable shiroAttributeSourceAdvisor
+| *Name*                              | *Default*           | *Meaning*
+| shiro.active                        | `true`              | if `false` the plugin is disabled
+| shiro.permissionDomainClassName     | _none_, must be set | the full class name of the permission domain class
+| shiro.rolePermissionDomainClassName | _none_              | if set, the full class name of the role permissions domain class
+| shiro.useCache                      | `true`              | whether to cache permission lookup; if you disable this they will be loaded from the database for every request
+| shiro.inspectShiroAnnotations       | `true`              | Whether to enable/disable shiroAttributeSourceAdvisor
 |====================

--- a/src/docs/introduction/history.adoc
+++ b/src/docs/introduction/history.adoc
@@ -1,5 +1,8 @@
 === History
 
+* Version 3.2
+** Added optional role-based permissions capability
+
 * Version 3.1.1
 ** released April 19, 2018
 ** Update Spring Security Shiro version to 1.4.0

--- a/src/docs/usage.adoc
+++ b/src/docs/usage.adoc
@@ -21,7 +21,7 @@ $ grails compile
 
 This will transitively install the http://grails.org/plugin/spring-security-core[Spring Security Core] plugin, so you'll need to configure that by running the `s2-quickstart` script.
 
-=== Permissions
+=== User Permissions
 
 To use the Shiro annotations and methods you need a way to associate roles and permissions with users. The Spring Security Core plugin already handles the role part for you, so you must configure permissions for this plugin. There is no script to create a domain class, but it's a very simple class and easy to create yourself. It can have any name and be in any package, but otherwise the structure must look like this:
 
@@ -58,6 +58,53 @@ import com.mycompany.myapp.MyShiroPermissionResolver
 
 beans = {
    shiroPermissionResolver(MyShiroPermissionResolver)
+}
+----
+
+=== Role Permissions
+
+Shiro can use both user-based and role-based permissions. The Spring Security Shiro plugin includes optional support for this capability. If role-based permissions are enabled, the effective permissions for a user becomes the union of both the user-based permissions and the role-based permissions for the user's roles, and all calls that expect permissions will use the union of the two. The Spring Security Core plugin handles the roles for you but you must configure permissions for the role.
+
+As with the user-based permissions, there is no script to create a domain class, but it is simple to create one. It can also have any name and be in any package, but otherwise the structure must look like this:
+
+[source,java]
+----
+package com.mycompany.myapp
+
+class RolePermission {
+    Role role
+    String permission
+
+    RolePermission(Role role, String permission) {
+        this.role = role
+    this.permission = permission
+    }
+
+    static constraints = {
+        permission unique: 'role'
+    }
+}
+----
+
+Register the class name along with the other Spring Security attributes in `application.groovy` (or `application.yml`) using the `grails.plugin.springsecurity.shiro.rolePermissionDomainClassName` property, e.g.
+
+[source,java]
+----
+grails.plugin.springsecurity.shiro.rolePermissionDomainClassName = 'com.mycompany.myapp.RolePermission'
+----
+
+You can add other properties and methods, but the plugin expects that there is a one-to-many between your role and permission classes, that the role property name is "`role`" (regardless of the actual class name), and the permission property name is "`permission`".
+
+If you need more flexibility, you can replace the Spring bean that looks up role-based permissions. Create a class in src/main/groovy that implements the `import org.apache.shiro.authz.permission.RolePermissionResolver` interface, and define the `Collection<Permission> resolvePermissionsInRole(String roleString)` method any way you like. Note that the collection of permissions returned are of type `org.apache.shiro.authz.Permission`, not the Permission you have defined in your application. You can use the `grails.plugin.springsecurity.shiro.GormShiroRolePermissionResolver` as an example for your own implementation.
+
+Register your bean as the `shiroRolePermissionResolver` bean in `resources.groovy`, for example
+
+[source,java]
+----
+import com.mycompany.myapp.MyShiroRolePermissionResolver
+
+beans = {
+   shiroRolePermissionResolver(MyShiroRolePermissionResolver)
 }
 ----
 

--- a/src/main/groovy/grails/plugin/springsecurity/shiro/GormShiroRolePermissionResolver.groovy
+++ b/src/main/groovy/grails/plugin/springsecurity/shiro/GormShiroRolePermissionResolver.groovy
@@ -1,0 +1,68 @@
+/* Copyright 2013-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package grails.plugin.springsecurity.shiro
+
+import grails.core.GrailsApplication
+import grails.plugin.springsecurity.SpringSecurityUtils
+import org.apache.shiro.authz.Permission
+import org.apache.shiro.authz.permission.RolePermissionResolver
+import org.apache.shiro.authz.permission.WildcardPermission
+
+class GormShiroRolePermissionResolver implements RolePermissionResolver {
+
+	GrailsApplication grailsApplication
+
+	@Override
+	Collection<Permission> resolvePermissionsInRole(String roleString) {
+		ConfigObject conf = SpringSecurityUtils.securityConfig
+
+		String rolePermissionDomainClassName = conf.shiro.rolePermissionDomainClassName
+		if (!rolePermissionDomainClassName) {
+			throw new RuntimeException('No value specified for the Shiro role permission class; ' +
+					'set the grails.plugin.springsecurity.shiro.rolePermissionDomainClassName attribute')
+		}
+
+		def rpdc = grailsApplication.getDomainClass(rolePermissionDomainClassName)
+		if (!rpdc) {
+			throw new RuntimeException("The specified role permission domain class '$rolePermissionDomainClassName' is not a domain class")
+		}
+
+		Class<?> RolePermission = rpdc.clazz
+
+		// Role property name comes from Spring Security
+		def rolePropertyName = conf.authority.nameField
+
+		if (!rolePropertyName) {
+			throw new RuntimeException("The Spring Security authority.nameField is not defined.")
+		}
+
+		List<String> stringPermissions = RolePermission.withCriteria {
+			role {
+				eq rolePropertyName, roleString
+			}
+			projections {
+				property 'permission'
+			}
+		}
+
+		List<Permission> permissions = []
+
+		stringPermissions.each { String perm ->
+			permissions << new WildcardPermission(perm)
+		}
+
+		return permissions
+	}
+}

--- a/src/main/groovy/grails/plugin/springsecurity/shiro/SpringSecurityShiroGrailsPlugin.groovy
+++ b/src/main/groovy/grails/plugin/springsecurity/shiro/SpringSecurityShiroGrailsPlugin.groovy
@@ -84,11 +84,20 @@ class SpringSecurityShiroGrailsPlugin extends Plugin {
 			grailsApplication = grailsApplication
 		}
 
+		if (conf.shiro.rolePermissionDomainClassName) {
+			shiroRolePermissionResolver(GormShiroRolePermissionResolver) {
+				grailsApplication = grailsApplication
+			}
+		}
+
 		boolean useCache = conf.shiro.useCache // true
 
 		springSecurityRealm(SpringSecurityRealm) {
 			authenticationTrustResolver = ref('authenticationTrustResolver')
 			shiroPermissionResolver = ref('shiroPermissionResolver')
+			if (conf.shiro.rolePermissionDomainClassName) {
+				rolePermissionResolver = ref('shiroRolePermissionResolver')
+			}
 			if (useCache) {
 				cacheManager = ref('shiroCacheManager')
 			}


### PR DESCRIPTION
Optionally enable Shiro role-based permissions. If the rolePermissionDomainClassName is defined, the plugin will now use role-based permissions in addition to user-based permissions.